### PR TITLE
Fix Flora Island ally not spawning

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+version 1.0.4.23
+- Scenarios
+	- Fixed Flora Island
+
 version 1.0.4.22
 - Scenarios 
 	- Fixed True Darkness

--- a/scenarios/17_Flora_Island.cfg
+++ b/scenarios/17_Flora_Island.cfg
@@ -720,8 +720,7 @@
 
         [filter]
             side=1
-            x=42-49
-            y=36-42
+            y=36-50
         [/filter]
 
         {LOYAL_UNIT 3 (Thug_Peasant) 44 39} {GUARDIAN}


### PR DESCRIPTION
Fast units could prevent the event from triggering, breaking the scenario.
Increased the trigger zone to compensate. 